### PR TITLE
fixes #26: autodiscover bubble exception if mails.py present

### DIFF
--- a/mail_factory/models.py
+++ b/mail_factory/models.py
@@ -2,6 +2,7 @@
 
 from django.conf import settings
 from django.utils.importlib import import_module
+from django.utils.module_loading import module_has_submodule
 
 
 def autodiscover():
@@ -11,7 +12,12 @@ def autodiscover():
         module = '%s.mails' % app  # Attempt to import the app's 'mails' module
         try:
             import_module(module)
-        except ImportError:
-            pass
+        except:
+            # Decide whether to bubble up this error. If the app just
+            # doesn't have a mails module, we can ignore the error
+            # attempting to import it, otherwise we want it to bubble up.
+            app_module = import_module(app)
+            if module_has_submodule(app_module, 'mails'):
+                raise
 
 autodiscover()


### PR DESCRIPTION
autodiscover shouldn't fail silently if mails.py module is present, but raised an ImportError (or whatever else) itself.
