### PR TITLE
Code repository moved to github.com/novapost

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -2,4 +2,4 @@
 Installation
 ############
 
-See https://github.com/novagile/django-mail-factory/ for details about the installation.
+See https://github.com/novapost/django-mail-factory/ for details about the installation.

--- a/README.rst
+++ b/README.rst
@@ -9,10 +9,10 @@ Django Mail Factory
 Django Mail Factory lets you manage your email in a multilingual project.
 
 * Authors: Rémy Hubscher and `contributors
-  <https://github.com/novagile/django-mail-factory/graphs/contributors>`_
+  <https://github.com/novapost/django-mail-factory/graphs/contributors>`_
 * Licence: BSD
 * Compatibility: Django 1.4+, python2.6 up to python3.3
-* Project URL: https://github.com/novagile/django-mail-factory
+* Project URL: https://github.com/novapost/django-mail-factory
 * Documentation: http://django-mail-factory.rtfd.org/
 
 
@@ -23,7 +23,7 @@ Setup your environment:
 
 ::
 
-    git clone https://github.com/novagile/django-mail-factory.git
+    git clone https://github.com/novapost/django-mail-factory.git
     cd django-mail-factory
 
 Hack and run the tests using `Tox <https://pypi.python.org/pypi/tox>`_ to test

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -24,7 +24,7 @@ Django Mail Factory has support for:
 Other resources
 ---------------
 
-Fork it on: http://github.com/novagile/django-mail-factory/
+Fork it on: http://github.com/novapost/django-mail-factory/
 
 Documentation: http://django-mail-factory.rtfd.org/
 
@@ -38,7 +38,7 @@ From PyPI::
 
 From the github tree::
 
-    pip install -e http://github.com/novagile/django-mail-factory/
+    pip install -e http://github.com/novapost/django-mail-factory/
 
 Then add ``mail_factory`` to your *INSTALLED_APPS*::
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':  # ``import setup`` doesn't trigger setup().
           keywords='django mail manager',
           author='Rémy Hubscher',
           author_email='hubscher.remy@gmail.com',
-          url='https://github.com/novagile/django-mail-factory',
+          url='https://github.com/novapost/django-mail-factory',
           license='BSD Licence',
           packages=find_packages(),
           include_package_data=True,


### PR DESCRIPTION
Searched/replaced "github.com/novagile" with "github.com/novapost"
