### PR TITLE
Include `form.media` (widget dependencies) in form.html

### DIFF
--- a/mail_factory/templates/mail_factory/form.html
+++ b/mail_factory/templates/mail_factory/form.html
@@ -12,6 +12,7 @@
 
 {% block extrahead %}
     {{ block.super }}
+    {{ form.media }}
 
     <script type="text/javascript">
         (function($) {


### PR DESCRIPTION
Without this, you can't use fancy widgets like autocompletes.